### PR TITLE
fix: Don't attempt to display a trend line if there's only one data point.

### DIFF
--- a/typetest/analyse.py
+++ b/typetest/analyse.py
@@ -77,6 +77,11 @@ def plot_wpm(output):
         names=["timestamp", "wpm", "accuracy", "actual_duration", "duration", "hash"],
     )
 
+    if len(df) < 2:
+        print("More data is needed, before analysing is possible. " +
+            "A minimum of 2 tests is required.")
+        return
+
     df.timestamp = pd.to_datetime(df.timestamp)
     # df = df.set_index(df.timestamp)
 
@@ -91,10 +96,6 @@ def plot_wpm(output):
         if min_wpm is None or row["wpm"] < min_wpm:
             min_wpm = row["wpm"]
 
-    if len(gdf) < 2:
-        print("More data is needed, before analysing is possible. " +
-            "A minimum of 2 tests is required.")
-        sys.exit(0)
     # grouped = sorted(gdf.items(), key=lambda x: x[1][1]['wpm'].mean(),
     #                  reverse=True)
     grouped = gdf.items()


### PR DESCRIPTION
When there's only one data-point, the call to np.polyfit in plotting the trendline fails and causes a crash with the following stack trace:

```
/home/vscode/.cache/pypoetry/virtualenvs/typetest-34tiyfZ9-py3.9/lib/python3.9/site-packages/numpy/lib/polynomial.py:659: RuntimeWarning: invalid value encountered in true_divide
  lhs /= scale
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/workspaces/typetest/typetest/analyse.py", line 40, in run
    main(**parse_args())
  File "/workspaces/typetest/typetest/analyse.py", line 59, in main
    plot_wpm(output)
  File "/workspaces/typetest/typetest/analyse.py", line 108, in plot_wpm
    trendline = np.poly1d(np.polyfit(x, y, 1))(x)
  File "<__array_function__ internals>", line 5, in polyfit
  File "/home/vscode/.cache/pypoetry/virtualenvs/typetest-34tiyfZ9-py3.9/lib/python3.9/site-packages/numpy/lib/polynomial.py", line 660, in polyfit
    c, resids, rank, s = lstsq(lhs, rhs, rcond)
  File "<__array_function__ internals>", line 5, in lstsq
  File "/home/vscode/.cache/pypoetry/virtualenvs/typetest-34tiyfZ9-py3.9/lib/python3.9/site-packages/numpy/linalg/linalg.py", line 2306, in lstsq
    x, resids, rank, s = gufunc(a, b, rcond, signature=signature, extobj=extobj)
ValueError: On entry to DLASCL parameter number 4 had an illegal value
```

This change removes the attempt to plot the trendline when there's only one (or zero) points.