### PR TITLE
Implement: plot_wpm_by_test_duration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.csv
 .vim/
 dist/
+venv/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "python.linting.flake8Enabled": true,
+  "python.linting.enabled": true,
+  "python.formatting.provider": "black"
+}

--- a/pyvenv.cfg
+++ b/pyvenv.cfg
@@ -1,0 +1,3 @@
+home = /usr/bin
+include-system-site-packages = false
+version = 3.8.10


### PR DESCRIPTION
   Others:
   * fix: 9+ lint issues in analyse.py
   * add: .vscode basic linting settings.json
   * modify: .gitignore to add venv/

This PR addresses issue #4 and implements a plot function to plot typing speeds based on time interval buckets (4 buckets).

Please complete these tasks before opening your PR:
- [X] My PR has been linted with flake8, i.e. `poetry run flake8`
- [X] My PR has been formatted with black, i.e. `poetry run black .`
- [X] My PR passes the tests, i.e. `poetry run python -m unittest`
