### PR TITLE
build: Pin python version.

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9.x'
       - name: Install poetry
         uses: abatilo/actions-poetry@v2.1.3
       - name: Install dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9.x'
       - name: Install poetry
         uses: abatilo/actions-poetry@v2.1.3
       - name: Install dependencies


### PR DESCRIPTION
Some dependencies don't install correctly in newly released Python 3.10. Pin to Python 3.9 in the workflows until this is fixed.

Please complete these tasks before opening your PR:
- [x] My PR has been linted with flake8, i.e. `poetry run flake8`
- [x] My PR has been formatted with black, i.e. `poetry run black .`
- [x] My PR passes the tests, i.e. `poetry run python -m unittest`
